### PR TITLE
Fix `lon_percentage` using midpoint latitude

### DIFF
--- a/src/map_manager.py
+++ b/src/map_manager.py
@@ -30,9 +30,12 @@ class MapManager:
         sw = bounding_box["sw"]
         ne = bounding_box["ne"]
 
+        # Use the midpoint latitude to compute a more accurate east-west distance
+        mid_lat = (sw["lat"] + ne["lat"]) / 2
+
         # Calculate the distance between southwest and northeast corners (both latitudinal and longitudinal distances)
         _, _, total_lat_distance = self.geod.inv(sw["lon"], sw["lat"], sw["lon"], ne["lat"])
-        _, _, total_lon_distance = self.geod.inv(sw["lon"], sw["lat"], ne["lon"], sw["lat"])
+        _, _, total_lon_distance = self.geod.inv(sw["lon"], mid_lat, ne["lon"], mid_lat)
 
         # Calculate the maximum of the two distances for square scaling
         max_distance = max(total_lat_distance, total_lon_distance)
@@ -41,7 +44,7 @@ class MapManager:
 
         # Calculate the distance from the southwest to the step's latitude and longitude
         _, _, lat_distance = self.geod.inv(sw["lon"], sw["lat"], sw["lon"], step.lat)
-        _, _, lon_distance = self.geod.inv(sw["lon"], sw["lat"], step.lon, sw["lat"])
+        _, _, lon_distance = self.geod.inv(sw["lon"], mid_lat, step.lon, mid_lat)
 
         if max_distance == total_lat_distance:
             lon_distance += diff_distance / 2


### PR DESCRIPTION
Previously, the east–west distances (`total_lon_distance` and `lon_distance`) were calculated at the southern latitude of each country's bounding box. This caused distorted scaling for countries located far from the equator with a wide north–south range (e.g., Norway) since the length of one degree of longitude decreases toward the poles.

I wrote this little fix to compute the longitude distances using the midpoint latitude of the bounding box to have a more consistent scale when positioning dot point on the SVG map